### PR TITLE
support all php 7 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "sitewards/fix-13929",
   "description": "An extension to fix the bug on GitHub issue #13929",
   "require": {
-    "php": "7.0.2|7.0.4|~7.0.6"
+    "php": "^7.0.0"
   },
   "type": "magento2-module",
   "version": "1.0.0",


### PR DESCRIPTION
is there a specific reason why for example php 7.1 is not supported?
It should not be a problem to include all php 7 versions or should it?